### PR TITLE
Vertically center content on about page

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,58 +1,6 @@
-@import "@fontsource/fira-mono";
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-:root {
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  --font-mono: "Fira Mono", monospace;
-  --secondary-color: #d0dde9;
-  --accent-color: #ff3e00;
-  --heading-color: rgba(0, 0, 0, 0.7);
-  --column-width: 42rem;
-  --column-margin-top: 4rem;
-  @apply text-gray-100;
-}
-
-body {
-  @apply bg-gray-900 min-h-screen m-0;
-}
-
-#svelte {
-  min-height: 100vh;
-  @apply min-h-screen flex flex-col;
-}
-
-h1,
-h2,
-p {
-  @apply font-normal leading-normal;
-}
-
-a {
-  @apply text-blue-400 hover:underline decoration-dashed;
-}
-
-h1 {
-  @apply text-3xl md:text-4xl font-semibold text-center pb-8;
-}
-
-h2 {
-  @apply text-lg;
-}
-
-pre {
-  font-size: 16px;
-  font-family: var(--font-mono);
-  background-color: rgba(255, 255, 255, 0.45);
-  border-radius: 3px;
-  box-shadow: 2px 2px 6px rgb(255 255 255 / 25%);
-  padding: 0.5em;
-  overflow-x: auto;
-  color: var(--text-color);
-}
-
-button {
-  @apply focus:outline-none p-2 rounded-md;
+.centered-content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }

--- a/src/routes/about.svelte
+++ b/src/routes/about.svelte
@@ -1,24 +1,4 @@
-<script context="module">
-  import { browser, dev } from "$app/env";
-
-  // we don't need any JS on this page, though we'll load
-  // it in dev so that we get hot module replacement...
-  export const hydrate = dev;
-
-  // ...but if the client-side router is already loaded
-  // (i.e. we came here from elsewhere in the app), use it
-  export const router = browser;
-
-  // since there's no dynamic data here, we can prerender
-  // it so that it gets served as a static asset in prod
-  export const prerender = true;
-</script>
-
-<svelte:head>
-  <title>About</title>
-</svelte:head>
-
-<div class="w-full max-w-3xl mx-auto text-center">
+<div class="w-full max-w-3xl mx-auto text-center centered-content">
   <h1>Wordle for Tailwind CSS</h1>
   <p>
     That's the idea. You get six attempts to guess five <a


### PR DESCRIPTION
The about page includes text that currently is placed at the top of the screen. The text should be vertically centred on the About page.